### PR TITLE
Add Vercel Analytics script to root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { GeistMono } from "geist/font/mono";
 import { GeistPixelSquare } from "geist/font/pixel";
 import { GeistSans } from "geist/font/sans";
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
 
 const themeCSS = generateThemeCSS(appConfig.theme, appConfig.radius);
@@ -80,6 +81,7 @@ export default function RootLayout({
             <TooltipProvider>{children}</TooltipProvider>
           </ThemeProvider>
         </TRPCReactProvider>
+        <Script src="/_vercel/insights/script.js" strategy="afterInteractive" />
       </body>
     </html>
   );


### PR DESCRIPTION
### Motivation
- Initialize Vercel Insights analytics site-wide by loading the Insights script in the root app layout so page metrics are collected across the application.

### Description
- Imported `Script` from `next/script` and added `<Script src="/_vercel/insights/script.js" strategy="afterInteractive" />` to `app/layout.tsx` so the insights script is injected after the app becomes interactive.

### Testing
- Ran `npm run lint` which completed successfully.
- Attempted `npm i @vercel/analytics` to add the optional package, but the install was blocked by the environment registry with a `403 Forbidden` error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ebc41660832599be4a29e5d909c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application monitoring to better track performance metrics and user interactions across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->