### PR TITLE
Improve landing hero layout and show GitHub stars

### DIFF
--- a/features/landing/Header.tsx
+++ b/features/landing/Header.tsx
@@ -12,8 +12,11 @@ import {
 } from "@/components/ui/tooltip";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
+import { getGitHubRepoStars } from "@/lib/github";
+
 export const Header = async () => {
   const session = await auth.api.getSession({ headers: await headers() });
+  const stars = await getGitHubRepoStars(appConfig.github);
 
   return (
     <div
@@ -58,10 +61,12 @@ export const Header = async () => {
             >
               <Button
                 variant="ghost"
-                size="icon"
-                className="group rounded-full active:scale-95 transition-all duration-300 text-muted-foreground hover:text-foreground hover:bg-muted"
+                className="group h-9 rounded-full active:scale-95 transition-all duration-300 text-muted-foreground hover:text-foreground hover:bg-muted px-3"
               >
                 <FaGithub className="transition-transform duration-500 ease-in-out group-hover:rotate-12 group-hover:scale-110" />
+                <span className="ml-1 text-xs font-medium tabular-nums">
+                  {stars.toLocaleString()}
+                </span>
               </Button>
             </Link>
           </TooltipTrigger>

--- a/features/landing/Hero.tsx
+++ b/features/landing/Hero.tsx
@@ -3,24 +3,31 @@ import { ArrowRight, DatabaseIcon } from "lucide-react";
 import { appConfig, landingConfig } from "@/config";
 import Link from "next/link";
 import { FaGithub } from "react-icons/fa";
+import { getGitHubRepoStars } from "@/lib/github";
 
 const { hero } = landingConfig;
 
-export const Hero = () => {
+export const Hero = async () => {
+  const stars = await getGitHubRepoStars(appConfig.github);
+
   return (
-    <section className="container mx-auto max-w-6xl px-6 py-24 md:py-32 text-left border-x border-dashed border-b">
-      <h1 className="text-4xl md:text-6xl tracking-tight font-medium relative">
-        <span className="text-primary inline-flex items-center gap-2">
+    <section className="container mx-auto max-w-6xl px-6 py-20 md:py-28 text-left border-x border-dashed border-b">
+      <div className="max-w-3xl">
+        <p className="mb-4 inline-flex items-center rounded-full border border-dashed bg-muted/60 px-3 py-1 text-xs font-medium tracking-wide text-muted-foreground">
+          Open-source starter, production ready
+        </p>
+        <h1 className="text-4xl md:text-6xl tracking-tight font-semibold leading-tight">
+          <span className="text-primary inline-flex items-center gap-2">
           {hero.titleAccent}
           <DatabaseIcon className="size-8 md:size-10 text-primary fill-primary/30" />
-        </span>
-        <br />
-        <span className="block mt-1">{hero.title}</span>
-      </h1>
+          </span>
+          <span className="block mt-2 text-foreground">{hero.title}</span>
+        </h1>
 
-      <p className="mt-5 text-base md:text-lg text-muted-foreground max-w-2xl leading-relaxed">
-        {hero.subtitle}
-      </p>
+        <p className="mt-5 text-base md:text-lg text-muted-foreground max-w-2xl leading-relaxed">
+          {hero.subtitle}
+        </p>
+      </div>
 
       <div className="flex flex-col sm:flex-row gap-4 mt-10">
         <Link href="/sign-in" prefetch className="cursor-pointer">
@@ -38,6 +45,9 @@ export const Hero = () => {
           <Button size="lg" variant="secondary" className="w-full sm:w-auto">
             <FaGithub />
             Star on GitHub
+            <span className="ml-1 rounded-md bg-background px-1.5 py-0.5 text-xs tabular-nums text-foreground">
+              {stars.toLocaleString()}
+            </span>
           </Button>
         </Link>
       </div>

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,47 @@
+const STAR_FALLBACK = 0;
+
+const parseRepoFromUrl = (repoUrl: string) => {
+  try {
+    const parsed = new URL(repoUrl);
+    const [owner, repo] = parsed.pathname.replace(/^\/+/, "").split("/");
+
+    if (!owner || !repo) {
+      return null;
+    }
+
+    return { owner, repo: repo.replace(/\.git$/, "") };
+  } catch {
+    return null;
+  }
+};
+
+export const getGitHubRepoStars = async (repoUrl: string) => {
+  const repo = parseRepoFromUrl(repoUrl);
+
+  if (!repo) {
+    return STAR_FALLBACK;
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${repo.owner}/${repo.repo}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+        },
+        next: {
+          revalidate: 3600,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      return STAR_FALLBACK;
+    }
+
+    const data = (await response.json()) as { stargazers_count?: number };
+    return data.stargazers_count ?? STAR_FALLBACK;
+  } catch {
+    return STAR_FALLBACK;
+  }
+};


### PR DESCRIPTION
### Motivation
- Tighten the landing page visual hierarchy and spacing so the hero reads cleaner and fits better on different viewports.
- Surface the repository popularity by showing the GitHub star count next to GitHub CTAs to increase social proof.

### Description
- Refactored `features/landing/Hero.tsx` to an async server component, reduced vertical padding, added a small badge, and adjusted heading/subheading typography and container width to improve spacing and readability.
- Updated `features/landing/Header.tsx` to fetch and render the repo star count inline next to the GitHub icon while preserving the existing tooltip and interactions.
- Added a new helper `lib/github.ts` that parses a GitHub repo URL, calls the GitHub API to read `stargazers_count`, applies a safe numeric fallback, and uses Next `revalidate` caching.

### Testing
- Ran `npm run lint`, which completed successfully without errors.
- Attempted `npm run dev`, but app compilation in this environment was blocked by a missing generated Prisma client import (`@/lib/generated/prisma/client`) unrelated to these UI changes.
- Tried automated screenshot capture via Playwright, but the browser run failed in this environment (Chromium crashed with SIGSEGV and Firefox timed out).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d44688e8883258018f612e69527bc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub repository star count now displays on the landing page
  * Real-time star metrics visible in header and hero sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->