### PR TITLE
Add RepoStars badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Auth, database, payments, AI chat, background jobs — fully wired.<br/>
 
 [Live Demo](https://gridly.akoder.xyz) · [Quick Start](#quick-start) · [Buy Me a Coffee](https://buymeacoffee.com/adikodez)
 
+[![RepoStars](https://repostars.dev/api/embed?repo=AdityaKodez%2Fgridly&theme=dark)](https://repostars.dev/?repos=AdityaKodez%2Fgridly&theme=dark)
+
 ![Gridly Preview](public/preview.png)
 
 </div>


### PR DESCRIPTION
### Motivation
- Surface the RepoStars embed badge in the README hero so the repository's repostars widget is visible alongside the project links and badges.

### Description
- Inserted the RepoStars embed link (`[![RepoStars](https://repostars.dev/api/embed?repo=AdityaKodez%2Fgridly&theme=dark)](...)`) into the top README hero section directly under the existing quick links.

### Testing
- Ran `git diff -- README.md` and `git status --short` to verify the change and committed the update successfully with message `Add RepoStars badge to README hero section`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1abde5a483258e84167174044044)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a RepoStars badge to the README for improved repository visibility and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->